### PR TITLE
Add a :learndot_id key

### DIFF
--- a/lib/learndot/events.rb
+++ b/lib/learndot/events.rb
@@ -18,6 +18,7 @@ class Learndot::Events
       classes.collect do | class_id, klass |
         location = locations[klass['locationId']]
 
+        klass[:learndot_id]      = klass['id'] # for consistency
         klass[:city]             = location['online'] ? location['name'] : location['address']['city']
         klass[:course_name]      = courses[klass['courseId']]['name']
         klass[:organizer]        = organizers[klass['organizerId']] ? organizers[klass['organizerId']]['_displayName_'] : ''


### PR DESCRIPTION
This is so that all consumers of this data can refer to elements in the same way. Symbolized keys are the ones we've decided on as a "public API", and stringified keys are learndot's internal messy schema
