### PR TITLE
(MAINT) Correct Component Endpoint

### DIFF
--- a/lib/learndot/learning_components.rb
+++ b/lib/learndot/learning_components.rb
@@ -4,15 +4,15 @@ class Learndot::LearningComponents
   end
 
   def retrieve_component(conditions, options = {orderBy: 'Name', asc: true})
-    learning_component = @api.search(:learning_component, conditions, options)
+    learning_component = @api.search(:content_component, conditions, options)
   end
 
   def create_component(conditions)
-    @api.create(:learning_component, conditions)
+    @api.create(:content_component, conditions)
   end
 
   def update_component(component_id, conditions={})
-    @api.update(:learning_component, conditions, component_id)
+    @api.update(:content_component, conditions, component_id)
   end
 end
 


### PR DESCRIPTION
The learning component class was pointing at the learning_component
endpoint, which was incorrect.  It needed to be pointing at the
content_component endpoint to be able to create a component.