### PR TITLE
(MAINT) Check ENV For Token First

### DIFF
--- a/lib/learndot/api.rb
+++ b/lib/learndot/api.rb
@@ -66,8 +66,7 @@ class Learndot::API
     begin
       return File.read(path).strip
     rescue => e
-      puts 'API token not found. Exiting'
-      puts e.message
+      raise "API token (in env variable or #{path}) not readable. Exiting."
     end
   end
 


### PR DESCRIPTION
Since the gem will soon be deployed to an automated system, rather
than used to run locally, easier to check for the environmental
variable first, then fall back to check for a file.  Also includes
error handling in case no token is provided or found