### PR TITLE
(MAINT) Nil value checks for API Class

### DIFF
--- a/lib/learndot.rb
+++ b/lib/learndot.rb
@@ -20,6 +20,8 @@ class Learndot
   attr_reader :api
 
   def initialize(debug = false, staging = false)
+    debug ||= false
+    staging ||= false
     @api = Learndot::API.new(nil, debug, staging)
   end
 

--- a/lib/learndot/api.rb
+++ b/lib/learndot/api.rb
@@ -12,7 +12,9 @@ class Learndot::API
       "#{level}: #{msg}\n"
     }
 
-    token ||= get_token
+    token   ||= get_token
+    debug   ||= false
+    staging ||= false
 
     # Set the base_url to the staging or production endpoint
     case staging


### PR DESCRIPTION
This checks for nil values being passed through to the API class.
Since nil is an accepted parameter value, it ignores the parameter
defaults, and has to be caught elsewhere.